### PR TITLE
move devdeps out of regular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,24 +31,20 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.3",
-    "gulp-jshint": "^2.0.4",
-    "gulp-load-plugins": "^1.4.0",
     "isemail": "^2.2.1",
-    "jshint": "^2.9.4",
     "minimist": "^1.1.0",
-    "mocha": "^3.2.0",
     "nodemailer": "^2.7.0",
-    "nodemailer-smtp-transport": "^2.7.2",
-    "should": "^11.1.1"
+    "nodemailer-smtp-transport": "^2.7.2"
   },
   "devDependencies": {
     "gulp": "^3.8.7",
-    "gulp-jshint": "^2.0.1",
-    "gulp-load-plugins": "^1.3.0",
+    "gulp-jshint": "^2.0.4",
+    "gulp-load-plugins": "^1.4.0",
     "gulp-mocha": "^3.0.1",
+    "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",
-    "mocha": "^3.1.0",
+    "mocha": "^3.2.0",
     "nodemailer-stub-transport": "^1.1.0",
-    "should": "^11.1.0"
+    "should": "^11.1.1"
   }
 }


### PR DESCRIPTION
at some point, a number of devdeps got added to dependencies, which'll cause installs from npm to include unnecessary deps.